### PR TITLE
Better debugging and bug fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,3 +75,6 @@ Here's an example docker-compose file, that will use your configured TLS cert:
          willnx/vlab-api-gateway
        dns:
          - <ip of vLab server>
+       enviroment:
+         - PRODUCTION=<true/false>
+         - VLAB_FQDN=<DNS name of the vLab server>

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-api-gateway",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.02.12',
+      version='2019.02.14',
       packages=find_packages(),
       description="Routes requests to vLab services",
       install_requires=['gunicorn', 'gevent', 'ujson', 'cffi>=1.11.5'],

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -148,6 +148,27 @@ class TestRelay(unittest.TestCase):
 
         self.assertTrue(isinstance(resp._resp, relay.NoHostResponse))
 
+    @patch.object(relay, 'HTTPConnection')
+    def test_connection_refused_status(self, fake_HTTPConnection):
+        """Connection Refused by upstream hosts returns HTTP 502 Bad Gateway"""
+        fake_resp = MagicMock()
+        fake_resp.getheaders.return_value = {'FooHeader' : 'true'}
+        fake_conn = MagicMock()
+        fake_conn.getresponse.return_value = fake_resp
+        fake_conn.request.side_effect = [ConnectionRefusedError('testing')]
+        fake_HTTPConnection.return_value = fake_conn
+
+        resp = relay.RelayQuery(host='fooHost',
+                                uri='/foo',
+                                method='GET',
+                                headers={},
+                                body=StringIO('{}'),
+                                port=5000)
+        expected_status = '502 Bad Gateway'
+
+        self.assertEqual(resp.status, expected_status)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -7,6 +7,8 @@ from socket import gaierror
 
 from vlab_api_gateway import relay
 
+relay.logger = MagicMock() # prevent SPAM in output while running tests
+
 
 class TestRelay(unittest.TestCase):
     """A suite of test cases for the ``relay.py`` module"""
@@ -126,6 +128,25 @@ class TestRelay(unittest.TestCase):
         expected = [('Content-Type', 'application/json')]
         actual = resp.headers
         self.assertEqual(expected, actual)
+
+    @patch.object(relay, 'HTTPConnection')
+    def test_connection_refused(self, fake_HTTPConnection):
+        """Connection Refused by upstream hosts returns a NoHostResponse response"""
+        fake_resp = MagicMock()
+        fake_resp.getheaders.return_value = {'FooHeader' : 'true'}
+        fake_conn = MagicMock()
+        fake_conn.getresponse.return_value = fake_resp
+        fake_conn.request.side_effect = [ConnectionRefusedError('testing')]
+        fake_HTTPConnection.return_value = fake_conn
+
+        resp = relay.RelayQuery(host='fooHost',
+                                uri='/foo',
+                                method='GET',
+                                headers={},
+                                body=StringIO('{}'),
+                                port=5000)
+
+        self.assertTrue(isinstance(resp._resp, relay.NoHostResponse))
 
 
 if __name__ == '__main__':

--- a/vlab_api_gateway/relay.py
+++ b/vlab_api_gateway/relay.py
@@ -58,6 +58,9 @@ class RelayQuery:
         except gaierror:
             logger.error('failed to resolve DNS host {} for URI {}'.format(host, uri))
             self._handle_no_host(host, uri)
+        except ConnectionRefusedError:
+            logger.error('Connection refused by host - URL {}:{}{}, TLS={}'.format(host, port, uri, tls))
+            self._handle_no_host(host, uri)
         else:
             self._resp = self._conn.getresponse()
             self._headers = self._resp.getheaders()

--- a/vlab_api_gateway/relay.py
+++ b/vlab_api_gateway/relay.py
@@ -6,7 +6,10 @@ a response to the calling WSGI application.
 from socket import gaierror
 from http.client import HTTPConnection, HTTPSConnection
 
+from vlab_api_gateway.std_logger import get_logger
 from vlab_api_gateway.constants import const
+
+logger = get_logger(__name__)
 
 
 class RelayQuery:
@@ -40,6 +43,7 @@ class RelayQuery:
         self._headers = None
         self._status = None
         if host is None:
+            logger.error('No host found for {} on {}'.format(method, uri))
             self._handle_no_host(host, uri)
         else:
             self._call_upstream(host, uri, method, headers, body, port, tls)
@@ -52,7 +56,7 @@ class RelayQuery:
         try:
             self._conn.request(method=method, url=uri, body=body, headers=headers)
         except gaierror:
-            # DNS resolution failure
+            logger.error('failed to resolve DNS host {} for URI {}'.format(host, uri))
             self._handle_no_host(host, uri)
         else:
             self._resp = self._conn.getresponse()

--- a/vlab_api_gateway/relay.py
+++ b/vlab_api_gateway/relay.py
@@ -60,15 +60,15 @@ class RelayQuery:
             self._handle_no_host(host, uri)
         except ConnectionRefusedError:
             logger.error('Connection refused by host - URL {}:{}{}, TLS={}'.format(host, port, uri, tls))
-            self._handle_no_host(host, uri)
+            self._handle_no_host(host, uri, status='502 Bad Gateway')
         else:
             self._resp = self._conn.getresponse()
             self._headers = self._resp.getheaders()
             self._status =  '{} {}'.format(self._resp.status, self._resp.reason)
 
-    def _handle_no_host(self, host, uri):
+    def _handle_no_host(self, host, uri, status='404 Not Found'):
         self._headers = [('Content-Type', 'application/json')]
-        self._status = '404 Not Found'
+        self._status = status
         self._resp = NoHostResponse(host, uri)
 
     @property


### PR DESCRIPTION
The lack of logging makes debugging issues found on the integration server (and by extension the production server once deployed) hard.

This PR adds some logging to the Relay object for the failure path. It also handles a ConnectionRefused error from an upstream server now.