### PR TITLE
Bug content headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-api-gateway",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.02.14',
+      version='2019.02.15',
       packages=find_packages(),
       description="Routes requests to vLab services",
       install_requires=['gunicorn', 'gevent', 'ujson', 'cffi>=1.11.5'],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -70,7 +70,7 @@ class TestServer(unittest.TestCase):
 
         _, called_kwargs = fake_RelayQuery.call_args
         proxied_headers = called_kwargs['headers']
-        expected_headers = {'Content-Length': '', 'Content-Type': ''}
+        expected_headers = {}
 
         self.assertEqual(proxied_headers, expected_headers)
 
@@ -84,7 +84,21 @@ class TestServer(unittest.TestCase):
 
         _, called_kwargs = fake_RelayQuery.call_args
         proxied_headers = called_kwargs['headers']
-        expected_headers = {'Content-Length': '', 'Content-Type': '', 'X-CUSTOM-HEADER': 'woot'}
+        expected_headers = {'X-CUSTOM-HEADER': 'woot'}
+
+        self.assertEqual(proxied_headers, expected_headers)
+
+    def test_content_headers(self, fake_RelayQuery):
+        """``application`` sends Content-Type and Content-Lenght headers when they exist"""
+        self.env['CONTENT_TYPE'] = 'application/json'
+        self.env['CONTENT_LENGTH'] = 50
+        fake_start_response = MagicMock()
+
+        vlab_api_gateway.server.application(self.env, fake_start_response)
+
+        _, called_kwargs = fake_RelayQuery.call_args
+        proxied_headers = called_kwargs['headers']
+        expected_headers = {'Content-Type': 'application/json', 'Content-Length': 50}
 
         self.assertEqual(proxied_headers, expected_headers)
 

--- a/vlab_api_gateway/server.py
+++ b/vlab_api_gateway/server.py
@@ -6,13 +6,18 @@ from http.client import HTTPConnection
 
 from vlab_api_gateway import router
 from vlab_api_gateway.relay import RelayQuery
+from vlab_api_gateway.std_logger import get_logger
 
+
+logger = get_logger(__name__)
 
 def application(env, start_response):
     """The callable function per the WSGI spec; PEP 333"""
     headers = {x[5:].replace('_', '-'):y for x, y in env.items() if x.startswith('HTTP_')}
-    headers['Content-Type'] = env.get('CONTENT_TYPE', '')
-    headers['Content-Length'] = env.get('CONTENT_LENGTH', '')
+    if env.get('CONTENT_TYPE', None):
+        headers['Content-Type'] = env['CONTENT_TYPE']
+    if env.get('CONTENT_LENGTH', None):
+        headers['Content-Length'] = env['CONTENT_LENGTH']
     headers.pop('CONNECTION', None) # let RelayQuery choose to use keepalives or not
     body = env['wsgi.input']
     uri = env.get('PATH_INFO', '')

--- a/vlab_api_gateway/server.py
+++ b/vlab_api_gateway/server.py
@@ -6,10 +6,7 @@ from http.client import HTTPConnection
 
 from vlab_api_gateway import router
 from vlab_api_gateway.relay import RelayQuery
-from vlab_api_gateway.std_logger import get_logger
 
-
-logger = get_logger(__name__)
 
 def application(env, start_response):
     """The callable function per the WSGI spec; PEP 333"""


### PR DESCRIPTION
The HTTP headers Content-Type and Content-Length should only be sent to the backend services if the client provides them. Because the API Gateway was _always_ sending them, it caused NGINX to reject the requests for docs.