### PR TITLE
Can now proxy to the ESXi service

### DIFF
--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -103,7 +103,11 @@ class TestConstants(unittest.TestCase):
     def test_known_hosts(self):
         """``SERVICE_MAP`` contains the expected set of service hosts"""
         known_hosts = set(router.SERVICE_MAP.keys())
-        expected_hosts = set(['snapshot', 'icap', 'centos', 'claritynow', 'router', 'gateway', 'insightiq', 'power', 'docs', 'onefs', 'windows', 'link', 'ecs', 'esrs', 'ipam', 'vlan', 'auth', 'cee', 'inventory', 'winserver'])
+        expected_hosts = set(['snapshot', 'icap', 'centos', 'claritynow',
+                              'router', 'gateway', 'insightiq', 'power', 'docs',
+                              'onefs', 'windows', 'link', 'ecs', 'esrs', 'ipam',
+                              'vlan', 'auth', 'cee', 'inventory', 'winserver',
+                              'esxi'])
 
         self.assertEqual(known_hosts, expected_hosts)
 

--- a/vlab_api_gateway/router.py
+++ b/vlab_api_gateway/router.py
@@ -31,6 +31,7 @@ SERVICE_MAP = {
     'ipam'       : ('UNKNOWN', True, 443),
     'docs'       : ('docs', False, 80),
     'snapshot'   : ('snapshot-api', False, 5000),
+    'esxi'       : ('esxi-api', False, 5000),
 }
 SERVICE = 3
 SERVICE_SUBGROUP = 4


### PR DESCRIPTION
This PR is the result of https://github.com/willnx/vlab/issues/32

The API Gateway can now route to the new ESXi service.